### PR TITLE
⏫ Assign - Make it work on subtasks

### DIFF
--- a/src/css/content.css
+++ b/src/css/content.css
@@ -61,7 +61,12 @@ img.ghx-avatar-img {
 }
 
 .bju-subtask-avatar img {
+	border-radius: 12px;
 	width: 24px;
-    height: 24px;
-    margin: 0 2px 0 11px;
+	height: 24px;
+	margin: 0 2px 0 11px;
+}
+
+span .bju-subtask-avatar img {
+	margin: 0;
 }

--- a/src/css/content.css
+++ b/src/css/content.css
@@ -59,3 +59,9 @@ img.ghx-avatar-img {
 	margin-right: 10px;
 	width: 30px;
 }
+
+.bju-subtask-avatar img {
+	width: 24px;
+    height: 24px;
+    margin: 0 2px 0 11px;
+}

--- a/src/css/content.css
+++ b/src/css/content.css
@@ -1,5 +1,6 @@
-.ghx-issue img.ghx-avatar-img,
-img.ghx-avatar-img {
+/* .ghx-issue img.ghx-avatar-img,
+img.ghx-avatar-img, */
+span[data-bju-assign="on"] {
 	cursor: pointer;
 }
 
@@ -46,7 +47,7 @@ img.ghx-avatar-img {
 	list-style-type: none;
 	margin: 0;
 	padding: 10px 20px;
-	width: 100%;
+	width: auto;
 }
 
 .usersDropdownItem:hover {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -48,6 +48,16 @@ function init() {
 
 	chrome.runtime.onMessage.addListener(processMessage)
 
+	chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+		debug('background.js::tabsOnUpdated', changeInfo)
+		if (changeInfo.url) {
+			chrome.tabs.sendMessage( tabId, {
+				message: 'urlChanged',
+				url: changeInfo.url
+			})
+		}
+	});
+
 	iconBadge.init()
 }
 

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -27,11 +27,13 @@ const windowOnload = () => {
 		debug('content.js::windowOnload', 'Initing modules.')
 		assign.init()
 
-		loaderObserver.observe(loaderElement, {
-			attributes: true,
-			attributeFilter: ['style'],
-			attributeOldValue: true
-		})
+		if (loaderObserver instanceof Node) {
+			loaderObserver.observe(loaderElement, {
+				attributes: true,
+				attributeFilter: ['style'],
+				attributeOldValue: true
+			})
+		}
 	})
 }
 

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,20 +1,8 @@
 import { requiredOptions, areRequiredOptionsSet, doesLocationHrefMatchBaseUrl } from './config'
 import { debug } from './lib/logger.js'
 
-// Import modules
-import assign from './modules/assign/assign.content'
-
-const onLoaderMutation = (mutations) => {
-	debug('content.js::onLoaderMutation', {mutations})
-
-	if (mutations[0].oldValue === 'display: block;') {
-		debug('content.js::onLoaderMutation', 'Reiniting')
-
-		assign.init()
-	}
-}
-const loaderObserver = new MutationObserver(onLoaderMutation)
-const loaderElement = document.getElementsByClassName('adg-throbber')[0]
+import JiraEvents from './jira/events/jira-events'
+import Modules from './modules/modules'
 
 const windowOnload = () => {
 	debug('content.js::windowOnload', 'Starting content')
@@ -24,16 +12,8 @@ const windowOnload = () => {
 			return false
 		}
 
-		debug('content.js::windowOnload', 'Initing modules.')
-		assign.init()
-
-		if (loaderObserver instanceof Node) {
-			loaderObserver.observe(loaderElement, {
-				attributes: true,
-				attributeFilter: ['style'],
-				attributeOldValue: true
-			})
-		}
+		JiraEvents.init()
+		Modules.init()
 	})
 }
 

--- a/src/js/jira/components/Issue.js
+++ b/src/js/jira/components/Issue.js
@@ -2,12 +2,27 @@ import { isNull } from 'lodash'
 
 import { debug } from '../../lib/logger'
 
+import config from '../jira.config'
 import { getIssuesList } from './IssuesList'
 
 export function getIssue(issueKey) {
 	let issuesList = getIssuesList()
 
 	return issuesList.querySelectorAll(`div.js-issue[data-issue-key=${issueKey}]`)[0]
+}
+
+export function getIssueKey(issue) {
+	return issue.getAttribute('data-issue-key')
+}
+
+export function getIssueAvatar(issue) {
+	return issue.querySelector(`.${config.avatar.className}`)
+}
+
+export function getIssueAvatarContainer(issue, pageType) {
+	debug('Issue::getIssueAvatarContainer::pageType', pageType)
+
+	return issue.querySelector(config.page[pageType].avatarContainerSelector)
 }
 
 export function getSelectedIssue() {

--- a/src/js/jira/components/Issue.js
+++ b/src/js/jira/components/Issue.js
@@ -15,8 +15,8 @@ export function getIssueKey(issue) {
 	return issue.getAttribute('data-issue-key')
 }
 
-export function getIssueAvatar(issue) {
-	return issue.querySelector(`.${config.avatar.className}`)
+export function getIssueAvatar(element) {
+	return element.querySelector(`.${config.avatar.className}`)
 }
 
 export function getIssueAvatarContainer(issue, pageType) {

--- a/src/js/jira/components/IssuesList.js
+++ b/src/js/jira/components/IssuesList.js
@@ -6,7 +6,19 @@ import { getCurrentPageConfig } from './Page'
 export function getIssuesList() {
 	let pageConfig = getCurrentPageConfig()
 
-	return document.getElementById(pageConfig.issuesListId)
+	if (typeof pageConfig.issuesListId !== 'undefined') {
+		return document.getElementById(pageConfig.issuesListId)
+	} else if (typeof pageConfig.issuesListClass !== 'undefined') {
+		return document.getElementsByClassName(pageConfig.issuesListClass)[0]
+	}
+
+	return false
+}
+
+export function getAllIssues() {
+	let issuesList = getIssuesList()
+
+	return issuesList !== false ? issuesList.querySelectorAll(`.${config.issue.className}`) : []
 }
 
 export function getAllAvatars() {

--- a/src/js/jira/components/Page.js
+++ b/src/js/jira/components/Page.js
@@ -19,13 +19,13 @@ export function getCurrentPageType() {
 		}
 	}
 
-	return 'other'
+	return false
 }
 
 export function getCurrentPageConfig() {
 	let type = getCurrentPageType()
 
-	if (type !== 'other') {
+	if (type !== false) {
 		return config.page[type]
 	}
 

--- a/src/js/jira/components/Subtask.js
+++ b/src/js/jira/components/Subtask.js
@@ -1,0 +1,9 @@
+import { debug } from '../../lib/logger'
+
+export function getSubtaskAvatar(subtask) {
+	debug('Subtask::getSubtaskAvatar::subtask', subtask)
+
+	let avatars = subtask.querySelectorAll('div span[role="img"]')
+
+	return avatars.length > 0 ? avatars[0] : false
+}

--- a/src/js/jira/components/Subtask.js
+++ b/src/js/jira/components/Subtask.js
@@ -3,7 +3,7 @@ import { debug } from '../../lib/logger'
 export function getSubtaskAvatar(subtask) {
 	debug('Subtask::getSubtaskAvatar::subtask', subtask)
 
-	let avatars = subtask.querySelectorAll('div span[role="img"]')
+	let avatars = subtask.querySelectorAll('div span[role="img"], .ghx-avatar-img')
 
 	return avatars.length > 0 ? avatars[0] : false
 }

--- a/src/js/jira/components/SubtasksList.js
+++ b/src/js/jira/components/SubtasksList.js
@@ -1,0 +1,77 @@
+import { debug } from '../../lib/logger'
+
+function findSubtaksTitle() {
+	let secondLevelHeaders = document.getElementsByTagName('h2')
+
+	for (let i = 0; i < secondLevelHeaders.length; i++) {
+		if (secondLevelHeaders[i].textContent.indexOf('Subtasks') > -1) {
+			return secondLevelHeaders[i]
+		}
+	}
+
+	return false
+}
+
+function findSubtasksList() {
+	let subtasksTitle = findSubtaksTitle()
+
+	return subtasksTitle !== false ? subtasksTitle.parentElement.parentElement.lastElementChild : false
+}
+
+function findSubtasksKeysElements() {
+	let subtasksList = findSubtasksList()
+
+	return subtasksList !== false ? subtasksList.querySelectorAll('div a[data-test-id*="key"]') : []
+}
+
+export function findSubtasks() {
+	let subtasksKeysElements = findSubtasksKeysElements()
+	let subtasks = []
+
+	for (let i = 0; i < subtasksKeysElements.length; i++) {
+		subtasks.push(subtasksKeysElements[i].parentElement)
+	}
+
+	return subtasks
+}
+
+export function findSubtasksWithIssueKeys() {
+	let subtasksKeysElements = findSubtasksKeysElements()
+	let subtasks = []
+
+	for (let i = 0; i < subtasksKeysElements.length; i++) {
+		debug('SubtasksList::findSubtasksWithIssueKeys::subtaskKeyElement', subtasksKeysElements[i])
+
+		subtasks.push({
+			element: subtasksKeysElements[i].parentElement,
+			issueKey: subtasksKeysElements[i].textContent
+		})
+	}
+
+	return subtasks
+}
+
+export function getSubtaskAvatar(subtask) {
+	debug('SubtasksList::getSubtaskAvatar::subtask', subtask)
+
+	let avatars = subtask.querySelectorAll('div span[role="img"]')
+
+	return avatars.length > 0 ? avatars[0] : false
+}
+
+export function hasSubtaskAvatar(subtask) {
+	avatar = getSubtaskAvatar(subtask)
+
+	return avatar !== false
+}
+
+export function checkSubtasksForAvatars() {
+	let subtasks = findSubtasks()
+	let results = []
+
+	for (let i = 0; i < subtasks.length; i++) {
+		results[i] = hasSubtaskAvatar(subtasks[i])
+	}
+
+	return results
+}

--- a/src/js/jira/components/SubtasksList.js
+++ b/src/js/jira/components/SubtasksList.js
@@ -1,6 +1,6 @@
 import { debug } from '../../lib/logger'
 
-function findSubtaksTitle() {
+function findSubtasksTitle() {
 	let secondLevelHeaders = document.getElementsByTagName('h2')
 
 	for (let i = 0; i < secondLevelHeaders.length; i++) {
@@ -13,7 +13,7 @@ function findSubtaksTitle() {
 }
 
 function findSubtasksList() {
-	let subtasksTitle = findSubtaksTitle()
+	let subtasksTitle = findSubtasksTitle()
 
 	return subtasksTitle !== false ? subtasksTitle.parentElement.parentElement.lastElementChild : false
 }
@@ -24,23 +24,12 @@ function findSubtasksKeysElements() {
 	return subtasksList !== false ? subtasksList.querySelectorAll('div a[data-test-id*="key"]') : []
 }
 
-export function findSubtasks() {
+export function getSubtasksWithIssueKeys() {
 	let subtasksKeysElements = findSubtasksKeysElements()
 	let subtasks = []
 
 	for (let i = 0; i < subtasksKeysElements.length; i++) {
-		subtasks.push(subtasksKeysElements[i].parentElement)
-	}
-
-	return subtasks
-}
-
-export function findSubtasksWithIssueKeys() {
-	let subtasksKeysElements = findSubtasksKeysElements()
-	let subtasks = []
-
-	for (let i = 0; i < subtasksKeysElements.length; i++) {
-		debug('SubtasksList::findSubtasksWithIssueKeys::subtaskKeyElement', subtasksKeysElements[i])
+		debug('SubtasksList::getSubtasksWithIssueKeys::subtaskKeyElement', subtasksKeysElements[i])
 
 		subtasks.push({
 			element: subtasksKeysElements[i].parentElement,
@@ -49,29 +38,4 @@ export function findSubtasksWithIssueKeys() {
 	}
 
 	return subtasks
-}
-
-export function getSubtaskAvatar(subtask) {
-	debug('SubtasksList::getSubtaskAvatar::subtask', subtask)
-
-	let avatars = subtask.querySelectorAll('div span[role="img"]')
-
-	return avatars.length > 0 ? avatars[0] : false
-}
-
-export function hasSubtaskAvatar(subtask) {
-	avatar = getSubtaskAvatar(subtask)
-
-	return avatar !== false
-}
-
-export function checkSubtasksForAvatars() {
-	let subtasks = findSubtasks()
-	let results = []
-
-	for (let i = 0; i < subtasks.length; i++) {
-		results[i] = hasSubtaskAvatar(subtasks[i])
-	}
-
-	return results
 }

--- a/src/js/jira/components/issue/Avatar.js
+++ b/src/js/jira/components/issue/Avatar.js
@@ -5,21 +5,35 @@ export function getIssueAvatar(issue) {
 }
 
 export function setIssueAvatarToLoading(issue) {
-	getIssueAvatar(issue).setAttribute('style', 'opacity: 50%;')
+	setAvatarToLoading(getIssueAvatar(issue))
 }
 
 export function setIssueAvatarToLoaded(issue) {
-	getIssueAvatar(issue).setAttribute('style', '')
+	setAvatarToLoaded(getIssueAvatar(issue))
 }
 
 export function setIssueAvatar(issue, imageSource, tooltip) {
-	let avatar = getIssueAvatar(issue)
+	setAvatarData(getIssueAvatar(issue), imageSource, tooltip)
+}
 
+export function setIssueAvatarToUnassigned(issue) {
+	setAvatarToUnassigned(getIssueAvatar(issue))
+}
+
+export function setAvatarToLoading(avatar) {
+	avatar.setAttribute('style', 'opacity: 50%;')
+}
+
+export function setAvatarToLoaded(avatar) {
+	avatar.setAttribute('style', '')
+}
+
+export function setAvatarData(avatar, imageSource, tooltip) {
 	avatar.setAttribute('style', '')
 	avatar.setAttribute('src', imageSource)
 	avatar.setAttribute('data-tooltip', tooltip)
 }
 
-export function setIssueAvatarToUnassigned(issue) {
-	setIssueAvatar(issue, config.avatar.unassigned.url, config.avatar.unassigned.name)
+export function setAvatarToUnassigned(avatar) {
+	setAvatarData(avatar, config.avatar.unassigned.url, config.avatar.unassigned.name)
 }

--- a/src/js/jira/events/elements/JiraIssueDetailView.js
+++ b/src/js/jira/events/elements/JiraIssueDetailView.js
@@ -1,0 +1,22 @@
+import { debug } from '../../../lib/logger'
+import IsVisible from './JiraIssueDetailView/IsVisible'
+import FinishedRerender from './JiraIssueDetailView/FinishedRerender'
+
+const element = document.getElementById('ghx-detail-view')
+
+function init() {
+	if (element instanceof Node) {
+		IsVisible.init(element)
+		FinishedRerender.init(element)
+	}
+}
+
+function disconnect() {
+	IsVisible.disconnect()
+	FinishedRerender.disconnect()
+}
+
+export default {
+	init,
+	disconnect
+}

--- a/src/js/jira/events/elements/JiraIssueDetailView/FinishedRerender.js
+++ b/src/js/jira/events/elements/JiraIssueDetailView/FinishedRerender.js
@@ -1,0 +1,44 @@
+import { debounce } from 'lodash'
+
+import { debug } from '../../../../lib/logger'
+
+let targetNode
+
+const emitEventDebounced = debounce(() => {
+	debug('JiraEvents::FinishedRerender::emitEventDebounced', 'JiraIssueDetailViewFinishedRerender')
+
+	window.dispatchEvent(new Event('JiraIssueDetailViewFinishedRerender'))
+	issueChangedObserver.disconnect()
+}, 1000)
+
+function observeIssueChanged(mutations) {
+	for (let i = 0; i < mutations.length; i++) {
+		if (mutations[i].addedNodes.length > 0) {
+			emitEventDebounced()
+		}
+	}
+}
+
+const issueChangedObserver = new MutationObserver(observeIssueChanged)
+
+function onJiraUrlChanged(e) {
+	debug('JiraEvents::FinishedRerender::onJiraUrlChanged', 'Setup observer')
+	issueChangedObserver.observe(targetNode, {
+		childList: true,
+		subtree: true
+	})
+}
+
+function init(element) {
+	targetNode = element
+	window.addEventListener('JiraUrlChanged', onJiraUrlChanged)
+}
+
+function disconnect() {
+	issueChangedObserver.disconnect()
+}
+
+export default {
+	init,
+	disconnect
+}

--- a/src/js/jira/events/elements/JiraIssueDetailView/IsVisible.js
+++ b/src/js/jira/events/elements/JiraIssueDetailView/IsVisible.js
@@ -1,0 +1,48 @@
+import { debug } from '../../../../lib/logger'
+
+function doesStyleImplyVisibility(styleAttribute) {
+	return styleAttribute === null || styleAttribute.indexOf('display: none') === -1
+}
+
+function observeVisibility(mutations) {
+	let states
+	let customEvent
+
+	for (let i = 0; i < mutations.length; i++) {
+		states = {
+			wasVisible: doesStyleImplyVisibility(mutations[i].oldValue),
+			isVisible: doesStyleImplyVisibility(mutations[i].target.getAttribute('style'))
+		}
+
+		if (states.wasVisible !== states.isVisible) {
+			if (states.isVisible === true) {
+				customEvent = new Event('JiraIssueDetailViewShown')
+				debug('JiraEvents::JiraIssueDetailView::IsVisible', 'JiraIssueDetailViewShown')
+			} else if (states.isVisible === false) {
+				customEvent = new Event('JiraIssueDetailViewHidden')
+				debug('JiraEvents::JiraIssueDetailView::IsVisible', 'JiraIssueDetailViewHidden')
+			}
+
+			window.dispatchEvent(customEvent)
+		}
+	}
+}
+
+const visibilityObserver = new MutationObserver(observeVisibility)
+
+function init(element) {
+	visibilityObserver.observe(element, {
+		attributes: true,
+		attributesFilter: ['style'],
+		attributeOldValue: true,
+	})
+}
+
+function disconnect() {
+	visibilityObserver.disconnect()
+}
+
+export default {
+	init,
+	disconnect
+}

--- a/src/js/jira/events/elements/JiraLoader.js
+++ b/src/js/jira/events/elements/JiraLoader.js
@@ -1,0 +1,49 @@
+import { debug } from '../../../lib/logger'
+
+const element = document.getElementsByClassName('adg-throbber')[0]
+
+function doesStyleImplyVisibility(styleAttribute) {
+	return styleAttribute.indexOf('display: block') > -1
+}
+
+function observeVisibility(mutations) {
+	let states
+	let customEvent
+
+	for (let i = 0; i < mutations.length; i++) {
+		states = {
+			wasVisible: doesStyleImplyVisibility(mutations[i].oldValue),
+			isVisible: doesStyleImplyVisibility(mutations[i].target.getAttribute('style'))
+		}
+
+		if (states.wasVisible !== states.isVisible) {
+			if (states.isVisible === true) {
+				customEvent = new Event('JiraLoaderShown')
+				debug('JiraEvents::JiraLoader::IsVisible', 'JiraLoaderShown')
+			} else if (states.isVisible === false) {
+				customEvent = new Event('JiraLoaderHidden')
+				debug('JiraEvents::JiraLoader::IsVisible', 'JiraLoaderHidden')
+			}
+
+			window.dispatchEvent(customEvent)
+		}
+	}
+}
+const visibilityObserver = new MutationObserver(observeVisibility)
+
+function init() {
+	visibilityObserver.observe(element, {
+		attributes: true,
+		attributesFilter: ['style'],
+		attributeOldValue: true,
+	})
+}
+
+function disconnect() {
+	visibilityObserver.disconnect()
+}
+
+export default {
+	init,
+	disconnect
+}

--- a/src/js/jira/events/jira-events.js
+++ b/src/js/jira/events/jira-events.js
@@ -1,0 +1,52 @@
+// TODO: This whole thing should definitely use Classes Composition
+
+import { debug } from '../../lib/logger'
+import { getCurrentPageType } from '../components/Page'
+
+import Url from './main/Url'
+import Page from './main/Page'
+
+import Backlog from './pages/Backlog'
+let pagesMap = {
+	backlog: Backlog,
+}
+let currentPageType
+
+function initPageEvents() {
+	currentPageType = getCurrentPageType()
+
+	if (pagesMap.hasOwnProperty(currentPageType)) {
+		pagesMap[currentPageType].init()
+		debug('JiraEvents::initPageEvents', `Page '${currentPageType}' initiated.`)
+	} else {
+		debug('JiraEvents::initPageEvents', `Page '${currentPageType}' unknown, skipped.`)
+	}
+}
+
+function disconnectPageEvents() {
+	if (pagesMap.hasOwnProperty(currentPageType)) {
+		pagesMap[currentPageType].disconnect()
+		debug('JiraEvents::disconnectPageEvents', `Page '${currentPageType}' disconnected.`)
+	} else {
+		debug('JiraEvents::disconnectPageEvents', `Page '${currentPageType}' unknown, skipped.`)
+	}
+}
+
+function onJiraUrlChanged() {
+	if (currentPageType !== getCurrentPageType()) {
+		disconnectPageEvents()
+		initPageEvents()
+	}
+}
+
+function init() {
+	Url.init()
+	Page.init()
+
+	initPageEvents()
+	window.addEventListener('JiraUrlChanged', onJiraUrlChanged)
+}
+
+export default {
+	init
+}

--- a/src/js/jira/events/main/Page.js
+++ b/src/js/jira/events/main/Page.js
@@ -1,0 +1,49 @@
+import { debounce } from 'lodash'
+
+import { debug } from '../../../lib/logger'
+import { getCurrentPageType } from '../../components/Page'
+
+let currentPageType
+let targetNode
+
+const emitEventDebounced = debounce(() => {
+	debug('JiraEvents::JiraPage::emitEventDebounced', 'JiraPageFinishedRender')
+
+	window.dispatchEvent(new Event('JiraPageFinishedRender'))
+	finishedRenderObserver.disconnect()
+}, 1000)
+
+function observeFinishedRender(mutations) {
+	for (let i = 0; i < mutations.length; i++) {
+		if (mutations[i].addedNodes.length > 0) {
+			emitEventDebounced()
+		}
+	}
+}
+
+const finishedRenderObserver = new MutationObserver(observeFinishedRender)
+
+function onJiraUrlChanged(e) {
+	// TODO: JiraPageChanged should be a separate event
+	let newPage = getCurrentPageType()
+
+	debug('JiraEvents::JiraPage::onJiraUrlChanged::pages', {currentPageType, newPage})
+	if (currentPageType !== newPage) {
+		debug('JiraEvents::JiraPage::onJiraUrlChanged', 'Setup observer')
+		currentPageType = newPage
+		finishedRenderObserver.observe(targetNode, {
+			childList: true,
+			subtree: true
+		})
+	}
+}
+
+function init(element) {
+	currentPageType = getCurrentPageType()
+	targetNode = document.getElementsByTagName('body')[0]
+	window.addEventListener('JiraUrlChanged', onJiraUrlChanged)
+}
+
+export default {
+	init
+}

--- a/src/js/jira/events/main/Url.js
+++ b/src/js/jira/events/main/Url.js
@@ -1,0 +1,16 @@
+import { debug } from '../../../lib/logger'
+
+function init() {
+	chrome.runtime.onMessage.addListener(
+		function(request, sender, sendResponse) {
+			if (request.message === 'urlChanged') {
+				window.dispatchEvent(new Event('JiraUrlChanged'))
+				debug('JiraEvents::Url', 'JiraUrlChanged')
+			}
+		}
+	);
+}
+
+export default {
+	init
+}

--- a/src/js/jira/events/pages/Backlog.js
+++ b/src/js/jira/events/pages/Backlog.js
@@ -1,0 +1,17 @@
+import JiraIssueDetailView from '../elements/JiraIssueDetailView'
+import JiraLoader from '../elements/JiraLoader'
+
+function init() {
+	JiraIssueDetailView.init()
+	JiraLoader.init()
+}
+
+function disconnect() {
+	JiraIssueDetailView.disconnect()
+	JiraLoader.disconnect()
+}
+
+export default {
+	init,
+	disconnect
+}

--- a/src/js/jira/jira.config.js
+++ b/src/js/jira/jira.config.js
@@ -35,5 +35,3 @@ export default {
 		'className': 'js-issue',
 	}
 }
-
-// sc-Ehqfj fpaCiR sc-kiXyGy csPzkd

--- a/src/js/jira/jira.config.js
+++ b/src/js/jira/jira.config.js
@@ -3,13 +3,26 @@ export default {
 		'backlog': {
 			'type': 'backlog',
 			'issuesListId': 'ghx-backlog',
-			'avatarContainerSelector': 'span.ghx-end'
+			'avatarContainerSelector': 'span.ghx-end',
+			'hasIssuesList': true,
+			'hasSubtasks': true,
+			'isAvatarWrapped': false,
 		},
 		'board': {
 			'type': 'board',
 			'issuesListId': 'ghx-pool',
-			'avatarContainerSelector': 'div.ghx-stat-2'
+			'avatarContainerSelector': 'div.ghx-stat-2',
+			'hasIssuesList': true,
+			'hasSubtasks': true,
+			'isAvatarWrapped': true,
 		},
+		'issue': {
+			'type': 'issue',
+			'issuesListClass': 'jcZTeP',
+			'avatarContainerSelector': '.sc-Ehqfj',
+			'hasIssuesList': false,
+			'hasSubtasks': true,
+		}
 	},
 	'avatar': {
 		'unassigned': {
@@ -22,3 +35,5 @@ export default {
 		'className': 'js-issue',
 	}
 }
+
+// sc-Ehqfj fpaCiR sc-kiXyGy csPzkd

--- a/src/js/jira/jira.config.js
+++ b/src/js/jira/jira.config.js
@@ -18,8 +18,6 @@ export default {
 		},
 		'issue': {
 			'type': 'issue',
-			'issuesListClass': 'jcZTeP',
-			'avatarContainerSelector': '.sc-Ehqfj',
 			'hasIssuesList': false,
 			'hasSubtasks': true,
 		}

--- a/src/js/modules/assign/assign.config.js
+++ b/src/js/modules/assign/assign.config.js
@@ -1,33 +1,41 @@
 export default {
-	'context': {
-		'backlog': {
-			'name': 'backlog',
-			'id': 'ghx-backlog',
-			'avatarContainerSelector': 'span.ghx-end'
-		},
-		'board': {
-			'name': 'board',
-			'id': 'ghx-pool',
-			'avatarContainerSelector': 'div.ghx-stat-2'
-		},
-	},
-	'avatars': {
-		'unassignedUrl': 'https://wnl-platform-production-storage.s3.eu-central-1.amazonaws.com/public/unassigned.png',
-		'avatarClass': 'ghx-avatar-img',
-		'backlog': {
-			'name': 'backlog',
-			'id': 'ghx-backlog',
-			'avatarContainerSelector': 'span.ghx-end'
-		},
-		'board': {
-			'name': 'board',
-			'id': 'ghx-pool',
-			'avatarContainerSelector': 'div.ghx-stat-2'
-		},
-	},
-	'issue': {
-		'className': 'js-issue',
-	},
+	// 'context': {
+	// 	'backlog': {
+	// 		'name': 'backlog',
+	// 		'id': 'ghx-backlog',
+	// 		'avatarContainerSelector': 'span.ghx-end'
+	// 	},
+	// 	'board': {
+	// 		'name': 'board',
+	// 		'id': 'ghx-pool',
+	// 		'avatarContainerSelector': 'div.ghx-stat-2'
+	// 	},
+	// 	'issue': {
+	// 		'name': 'issue',
+	// 		'class': 'jcZTeP',
+	// 		'avatarContainerSelector': 'div.sc-fhiYOA'
+	// 	}
+	// },
+	// 'avatars': {
+	// 	'unassignedUrl': 'https://wnl-platform-production-storage.s3.eu-central-1.amazonaws.com/public/unassigned.png',
+	// 	'avatarClass': 'ghx-avatar-img',
+	// 	'backlog': {
+	// 		'name': 'backlog',
+	// 		'id': 'ghx-backlog',
+	// 		'avatarContainerSelector': 'span.ghx-end'
+	// 	},
+	// 	'board': {
+	// 		'name': 'board',
+	// 		'id': 'ghx-pool',
+	// 		'avatarContainerSelector': 'div.ghx-stat-2'
+	// 	},
+	// 	'issue': {
+	// 		'avatarContainerSelector': 'div.sc-fhiYOA'
+	// 	}
+	// },
+	// 'issue': {
+	// 	'className': 'js-issue',
+	// },
 	dropdown: {
 		height: 250,
 		width: 300

--- a/src/js/modules/assign/assign.config.js
+++ b/src/js/modules/assign/assign.config.js
@@ -1,41 +1,4 @@
 export default {
-	// 'context': {
-	// 	'backlog': {
-	// 		'name': 'backlog',
-	// 		'id': 'ghx-backlog',
-	// 		'avatarContainerSelector': 'span.ghx-end'
-	// 	},
-	// 	'board': {
-	// 		'name': 'board',
-	// 		'id': 'ghx-pool',
-	// 		'avatarContainerSelector': 'div.ghx-stat-2'
-	// 	},
-	// 	'issue': {
-	// 		'name': 'issue',
-	// 		'class': 'jcZTeP',
-	// 		'avatarContainerSelector': 'div.sc-fhiYOA'
-	// 	}
-	// },
-	// 'avatars': {
-	// 	'unassignedUrl': 'https://wnl-platform-production-storage.s3.eu-central-1.amazonaws.com/public/unassigned.png',
-	// 	'avatarClass': 'ghx-avatar-img',
-	// 	'backlog': {
-	// 		'name': 'backlog',
-	// 		'id': 'ghx-backlog',
-	// 		'avatarContainerSelector': 'span.ghx-end'
-	// 	},
-	// 	'board': {
-	// 		'name': 'board',
-	// 		'id': 'ghx-pool',
-	// 		'avatarContainerSelector': 'div.ghx-stat-2'
-	// 	},
-	// 	'issue': {
-	// 		'avatarContainerSelector': 'div.sc-fhiYOA'
-	// 	}
-	// },
-	// 'issue': {
-	// 	'className': 'js-issue',
-	// },
 	dropdown: {
 		height: 250,
 		width: 300

--- a/src/js/modules/assign/assign.content.js
+++ b/src/js/modules/assign/assign.content.js
@@ -6,19 +6,45 @@ import unassignedAvatar from './components/unassignedAvatar'
 import unassignShortcut from './components/unassignShortcut'
 import assignDropdown from './components/assignDropdown'
 
+function isCurrentPageSupported() {
+	const supportedPages = ['backlog', 'board', 'issue']
+	return supportedPages.indexOf(getCurrentPageType()) > -1
+}
+
+async function onJiraPageFinishedRender(e) {
+	if (!isCurrentPageSupported()) return false
+
+	await unassignedAvatar.rebind()
+	assignDropdown.rebind()
+}
+
+async function onJiraLoaderHidden(e) {
+	if (!isCurrentPageSupported()) return false
+
+	await unassignedAvatar.rebind()
+	assignDropdown.rebind()
+}
+
+async function onJiraIssueDetailViewFinishedRerender(e) {
+	if (!isCurrentPageSupported()) return false
+
+	await unassignedAvatar.rebind({skipIssues: true})
+	assignDropdown.rebind()
+}
+
 const init = async () => {
 	debug('assign::init', 'Initiating assign module.')
-
-	const supportedPages = ['backlog', 'board', 'issue']
-	if (supportedPages.indexOf(getCurrentPageType()) === -1) {
-		return false
-	}
+	if (!isCurrentPageSupported()) return false
 
 	debug('assign::init', 'Loading components.')
-
 	await unassignedAvatar.init()
 	assignDropdown.init()
 	unassignShortcut.init()
+
+	debug('assign::init', 'Binding to JIRA events.')
+	window.addEventListener('JiraPageFinishedRender', onJiraPageFinishedRender)
+	window.addEventListener('JiraLoaderHidden', onJiraLoaderHidden)
+	window.addEventListener('JiraIssueDetailViewFinishedRerender', onJiraIssueDetailViewFinishedRerender)
 }
 
 export default {

--- a/src/js/modules/assign/assign.content.js
+++ b/src/js/modules/assign/assign.content.js
@@ -9,7 +9,7 @@ import assignDropdown from './components/assignDropdown'
 const init = async () => {
 	debug('assign::init', 'Initiating assign module.')
 
-	const supportedPages = ['backlog', 'board']
+	const supportedPages = ['backlog', 'board', 'issue']
 	if (supportedPages.indexOf(getCurrentPageType()) === -1) {
 		return false
 	}

--- a/src/js/modules/assign/components/assignDropdown.js
+++ b/src/js/modules/assign/components/assignDropdown.js
@@ -7,7 +7,7 @@ import { usersGetAll, issueAssignUser } from '../../../lib/jira-background-api'
 import config from '../../../jira/jira.config'
 import { getAllAvatars } from '../../../jira/components/IssuesList'
 import { getIssue } from '../../../jira/components/Issue'
-import { setIssueAvatarToLoading, setIssueAvatar } from '../../../jira/components/issue/Avatar'
+import { setAvatarToLoading, setAvatarData } from '../../../jira/components/issue/Avatar'
 
 import assignConfig from '../assign.config'
 
@@ -157,21 +157,26 @@ function listenerShowDropdownOnClick(e) {
 	e.preventDefault()
 	e.stopPropagation()
 
-	let issueItem = findElementByClassName(e.path, config.issue.className)
-	if (issueItem === false) {
-		return false
+	// let issueItem = findElementByClassName(e.path, config.issue.className)
+	// if (issueItem === false) {
+	// 	return false
+	// }
+
+	let issueKey = e.target.getAttribute('data-bju-issue-key')
+
+	if (typeof issueKey === 'undefined') {
+		issueKey = e.target.querySelector(`[data-bju-issue-key]`).getAttribute('data-bju-issue-key')
 	}
 
-	let issueKey = issueItem.getAttribute('data-issue-key')
 	let position = dropdownPositionFromEvent(e)
 
 	showDropdown(issueKey, position.left, position.top)
 }
 
 function bindShowDropdownOnAvatarClick() {
-	getAllAvatars().forEach(element => {
+	document.querySelectorAll('[data-bju-assign]').forEach(element => {
 		if (element.getAttribute('listener') !== 'true') {
-			element.addEventListener('click', listenerShowDropdownOnClick, true)
+			element.addEventListener('click', listenerShowDropdownOnClick, {capture: true})
 			element.setAttribute('listener', 'true')
 		}
 	})
@@ -227,13 +232,13 @@ async function listenerAssignUserOnClick(e) {
 	let response
 	let issueKey = dropdown.getAttribute('data-issue-key')
 	let accountId = userListItem.getAttribute('data-accountId')
-	let issue = getIssue(issueKey)
+	let avatar = document.querySelector(`[data-bju-issue-key="${issueKey}"]`)
 
-	setIssueAvatarToLoading(issue)
+	setAvatarToLoading(avatar)
 	response = await issueAssignUser(issueKey, accountId)
 
 	let newUser = getUserListItemData(userListItem)
-	setIssueAvatar(issue, newUser.avatar.src, newUser.displayName)
+	setAvatarData(avatar, newUser.avatar.src, newUser.displayName)
 
 	hideDropdown()
 }

--- a/src/js/modules/assign/components/assignDropdown.js
+++ b/src/js/modules/assign/components/assignDropdown.js
@@ -156,6 +156,8 @@ function getUserListItemData(userListItem) {
 // Show dropdown on click
 
 function listenerShowDropdownOnClick(e) {
+	debug('assignDropdown::listenerShowDropdownOnClick', e)
+
 	e.preventDefault()
 	e.stopPropagation()
 
@@ -257,6 +259,10 @@ function bindAssignOnClick () {
  * 5. Init and export
  */
 
+const rebind = () => {
+	bindShowDropdownOnAvatarClick()
+}
+
 const init = async () => {
 	await setup ()
 	await renderUsersList('')
@@ -268,5 +274,6 @@ const init = async () => {
 }
 
 export default {
-	init
+	init,
+	rebind
 }

--- a/src/js/modules/assign/components/assignDropdown.js
+++ b/src/js/modules/assign/components/assignDropdown.js
@@ -176,11 +176,10 @@ function listenerShowDropdownOnClick(e) {
 function bindShowDropdownOnAvatarClick() {
 	document.querySelectorAll('[data-bju-assign]').forEach(element => {
 		if (element.getAttribute('listener') !== 'true') {
-			element.addEventListener('click', listenerShowDropdownOnClick, {capture: true})
+			element.addEventListener('click', listenerShowDropdownOnClick, { capture: true })
 			element.setAttribute('listener', 'true')
 		}
 	})
-
 }
 
 // Hide dropdown on click

--- a/src/js/modules/assign/components/assignDropdown.js
+++ b/src/js/modules/assign/components/assignDropdown.js
@@ -8,6 +8,8 @@ import config from '../../../jira/jira.config'
 import { getAllAvatars } from '../../../jira/components/IssuesList'
 import { getIssue } from '../../../jira/components/Issue'
 import { setAvatarToLoading, setAvatarData } from '../../../jira/components/issue/Avatar'
+// TODO: This should be part of the Avatar component
+import UnassignedAvatar from './unassignedAvatar'
 
 import assignConfig from '../assign.config'
 
@@ -157,11 +159,6 @@ function listenerShowDropdownOnClick(e) {
 	e.preventDefault()
 	e.stopPropagation()
 
-	// let issueItem = findElementByClassName(e.path, config.issue.className)
-	// if (issueItem === false) {
-	// 	return false
-	// }
-
 	let issueKey = e.target.getAttribute('data-bju-issue-key')
 
 	if (typeof issueKey === 'undefined') {
@@ -231,13 +228,21 @@ async function listenerAssignUserOnClick(e) {
 	let response
 	let issueKey = dropdown.getAttribute('data-issue-key')
 	let accountId = userListItem.getAttribute('data-accountId')
-	let avatar = document.querySelector(`[data-bju-issue-key="${issueKey}"]`)
 
+	let avatar = document.querySelector(`[data-bju-issue-key="${issueKey}"]`)
 	setAvatarToLoading(avatar)
+
 	response = await issueAssignUser(issueKey, accountId)
 
 	let newUser = getUserListItemData(userListItem)
-	setAvatarData(avatar, newUser.avatar.src, newUser.displayName)
+
+	if (avatar.tagName === 'IMG') {
+		setAvatarData(avatar, newUser.avatar.src, newUser.displayName)
+	} else {
+		let newAvatar = UnassignedAvatar.createUnassignedAvatar(issueKey, true)
+		avatar.parentNode.replaceChild(newAvatar, avatar)
+		bindShowDropdownOnAvatarClick()
+	}
 
 	hideDropdown()
 }

--- a/src/js/modules/assign/components/unassignShortcut.js
+++ b/src/js/modules/assign/components/unassignShortcut.js
@@ -12,6 +12,7 @@ function isKeyPressedInEditableElement(e) {
 
 async function listenerUnassignCurrentIssueOnKeyDown(e) {
 	let issueKey = getSelectedIssueKeyFromUrl()
+	// TODO: This breaks for a single issue view - let's fix it!
 	let issue = getIssue(issueKey)
 
 	debug('unassignShortcut::listenerUnassignCurrentIssueOnKeyDown::event', e)

--- a/src/js/modules/assign/components/unassignedAvatar.js
+++ b/src/js/modules/assign/components/unassignedAvatar.js
@@ -3,7 +3,9 @@ import { debug } from '../../../lib/logger'
 import config from '../../../jira/jira.config'
 
 import { getCurrentPageType } from '../../../jira/components/Page'
-import { getAllAvatarContainers } from '../../../jira/components/IssuesList'
+import { getAllAvatarContainers, getAllIssues } from '../../../jira/components/IssuesList'
+import { getIssueKey, getIssueAvatar, getIssueAvatarContainer } from '../../../jira/components/Issue'
+import { findSubtasks, findSubtasksWithIssueKeys, hasSubtaskAvatar, getSubtaskAvatar } from '../../../jira/components/SubtasksList'
 
 /**
  * Constants
@@ -11,36 +13,120 @@ import { getAllAvatarContainers } from '../../../jira/components/IssuesList'
 
 const pageType = getCurrentPageType()
 
-const unassignedAvatarImg = `<img src="${config.avatar.unassigned.url}"
-	class="${config.avatar.className}" data-tooltip="${config.avatar.unassigned.name}">`
+// const unassignedAvatarImg = `<img src="${config.avatar.unassigned.url}"
+// 	class="${config.avatar.className}" data-tooltip="${config.avatar.unassigned.name}" data-bju-assign="on">`
 
-const unassignedAvatarHtml = {
-	'backlog': unassignedAvatarImg,
-	'board': `<span class="ghx-field">${unassignedAvatarImg}</span>`
-}
+// const unassignedAvatarIssue = `
+// 	<div class="sc-gbuiJB gWiorg sc-gGsJSs eihPQS">
+// 		<div>
+// 			<div style="display: inline-block; position: relative; outline: 0px; height: 28px; width: 28px;">
+// 				<span class="styledCache__StyledSpan-zohhd2-3 fmTriT">
+// 					<span role="img" aria-label="${config.avatar.unassigned.name}" style="background-color: transparent; background-image: url(&quot;${config.avatar.unassigned.url}&quot;); background-position: center center; background-repeat: no-repeat; background-size: cover; border-radius: 50%; display: flex; flex: 1 1 100%; height: 100%; width: 100%;"></span>
+// 				</span>
+// 			</div>
+// 		</div>
+// 	</div>
+// `
+
+// const unassignedAvatarHtml = {
+// 	'backlog': unassignedAvatarImg,
+// 	'board': `<span class="ghx-field">${unassignedAvatarImg}</span>`,
+// }
+//
+const unassignedAvatarElement = createUnassignedAvatarImgElement()
+// avatarElement.innerHTML = `<span class="bju-subtask-avatar">${unassignedAvatarImg}</span>`
 
 /**
  * Functions
  */
 
-function injectUnassignedAvatarHtml(element) {
-	if (element.innerHTML.indexOf(config.avatar.className) === -1) {
-		element.innerHTML = unassignedAvatarHtml[pageType] + element.innerHTML
+function createUnassignedAvatarImgElement() {
+	let element = document.createElement('img')
+
+	element.setAttribute('src', config.avatar.unassigned.url)
+	element.setAttribute('class', config.avatar.className)
+	element.setAttribute('data-tooltip', config.avatar.unassigned.name)
+
+	return element
+}
+
+function wrapElementWithSpan(element, className) {
+	let span = document.createElement('span')
+	span.setAttribute('class', className)
+
+	span.appendChild(element)
+
+	return span
+}
+
+function setupAvatarData(avatar, issueKey) {
+	avatar.setAttribute('data-bju-assign', 'on')
+	avatar.setAttribute('data-bju-issue-key', issueKey)
+
+	return avatar
+}
+
+// function injectUnassignedAvatarHtml(element) {
+// 	let avatar = element.querySelector(`.${config.avatar.className}`)
+//
+// 	if (avatar === null) {
+// 		avatar = avatar.in
+// 		element.innerHTML = unassignedAvatarHtml[pageType] + element.innerHTML
+// 	}  else {
+// 		avatar.setAttribute(avatar)
+// 	}
+// }
+
+function injectUnassignedAvatars() {
+	let issues = getAllIssues()
+
+	debug('unassignedAvatar::injectUnassignedAvatars::issues', issues)
+
+	for (let i = 0; i < issues.length; i++) {
+		let issueKey = getIssueKey(issues[i])
+		let avatar = getIssueAvatar(issues[i])
+
+		if (avatar !== null) {
+			setupAvatarData(avatar, issueKey)
+		} else {
+			let unassignedAvatar = setupAvatarData(createUnassignedAvatarImgElement(), issueKey)
+			let avatarContainer = getIssueAvatarContainer(issues[i], pageType)
+
+			if (config.page[pageType].isAvatarWrapped) {
+				unassignedAvatar = wrapElementWithSpan(unassignedAvatar, 'ghx-field')
+			}
+
+			unassignedAvatar = avatarContainer.insertBefore(unassignedAvatar, avatarContainer.firstElementChild)
+		}
 	}
 }
 
-function injectUnassignedAvatars() {
-	let avatarContainers = getAllAvatarContainers()
+function injectUnassignedAvatarsToSubtasks() {
+	let avatar
 
-	debug('unassignedAvatar::injectUnassignedAvatars::avatarContainers', avatarContainers)
+	let subtasks = findSubtasksWithIssueKeys()
 
-	avatarContainers.forEach(element => {
-		injectUnassignedAvatarHtml(element)
-	})
+	for (let i = 0; i < subtasks.length; i++) {
+		avatar = getSubtaskAvatar(subtasks[i].element)
+
+		if (avatar === false) {
+			avatar = setupAvatarData(unassignedAvatarElement, subtasks[i].issueKey)
+			avatar = wrapElementWithSpan(avatar, 'bju-subtask-avatar')
+
+			injectUnassignedAvatarHtmlToSubtask(subtasks[i].element, avatar)
+		} else {
+			setupAvatarData(avatar, subtasks[i].issueKey)
+		}
+	}
+}
+
+function injectUnassignedAvatarHtmlToSubtask(subtask, avatar) {
+	avatar = subtask.insertBefore(avatar, subtask.lastElementChild)
 }
 
 const init = async () => {
 	await injectUnassignedAvatars()
+	await injectUnassignedAvatarsToSubtasks()
 }
 
 export default {

--- a/src/js/modules/assign/components/unassignedAvatar.js
+++ b/src/js/modules/assign/components/unassignedAvatar.js
@@ -2,6 +2,7 @@ import { debug } from '../../../lib/logger'
 
 import config from '../../../jira/jira.config'
 
+import { setAvatarData } from '../../../jira/components/issue/Avatar'
 import { getCurrentPageType } from '../../../jira/components/Page'
 import { getAllAvatarContainers, getAllIssues } from '../../../jira/components/IssuesList'
 import { getIssueKey, getIssueAvatar, getIssueAvatarContainer } from '../../../jira/components/Issue'
@@ -77,8 +78,7 @@ function injectUnassignedAvatarsToSubtasks() {
 		avatar = getSubtaskAvatar(subtasks[i].element)
 
 		if (avatar === false) {
-			avatar = setupAvatarData(createUnassignedAvatarImgElement(), subtasks[i].issueKey)
-			avatar = wrapElementWithSpan(avatar, 'bju-subtask-avatar')
+			avatar = createUnassignedAvatar(subtasks[i].issueKey, true)
 
 			injectUnassignedAvatarHtmlToSubtask(subtasks[i].element, avatar)
 		} else {
@@ -91,11 +91,22 @@ function injectUnassignedAvatarHtmlToSubtask(subtask, avatar) {
 	avatar = subtask.insertBefore(avatar, subtask.lastElementChild)
 }
 
+function createUnassignedAvatar(issueKey, wrapWithSpan=false) {
+	let avatar = setupAvatarData(createUnassignedAvatarImgElement(), issueKey)
+
+	if (wrapWithSpan) {
+		avatar = wrapElementWithSpan(avatar, 'bju-subtask-avatar')
+	}
+
+	return avatar
+}
+
 const init = async () => {
 	await injectUnassignedAvatars()
 	await injectUnassignedAvatarsToSubtasks()
 }
 
 export default {
-	init
+	init,
+	createUnassignedAvatar
 }

--- a/src/js/modules/assign/components/unassignedAvatar.js
+++ b/src/js/modules/assign/components/unassignedAvatar.js
@@ -5,36 +5,14 @@ import config from '../../../jira/jira.config'
 import { getCurrentPageType } from '../../../jira/components/Page'
 import { getAllAvatarContainers, getAllIssues } from '../../../jira/components/IssuesList'
 import { getIssueKey, getIssueAvatar, getIssueAvatarContainer } from '../../../jira/components/Issue'
-import { findSubtasks, findSubtasksWithIssueKeys, hasSubtaskAvatar, getSubtaskAvatar } from '../../../jira/components/SubtasksList'
+import { findSubtasks, getSubtasksWithIssueKeys } from '../../../jira/components/SubtasksList'
+import { getSubtaskAvatar } from '../../../jira/components/Subtask'
 
 /**
  * Constants
  */
 
 const pageType = getCurrentPageType()
-
-// const unassignedAvatarImg = `<img src="${config.avatar.unassigned.url}"
-// 	class="${config.avatar.className}" data-tooltip="${config.avatar.unassigned.name}" data-bju-assign="on">`
-
-// const unassignedAvatarIssue = `
-// 	<div class="sc-gbuiJB gWiorg sc-gGsJSs eihPQS">
-// 		<div>
-// 			<div style="display: inline-block; position: relative; outline: 0px; height: 28px; width: 28px;">
-// 				<span class="styledCache__StyledSpan-zohhd2-3 fmTriT">
-// 					<span role="img" aria-label="${config.avatar.unassigned.name}" style="background-color: transparent; background-image: url(&quot;${config.avatar.unassigned.url}&quot;); background-position: center center; background-repeat: no-repeat; background-size: cover; border-radius: 50%; display: flex; flex: 1 1 100%; height: 100%; width: 100%;"></span>
-// 				</span>
-// 			</div>
-// 		</div>
-// 	</div>
-// `
-
-// const unassignedAvatarHtml = {
-// 	'backlog': unassignedAvatarImg,
-// 	'board': `<span class="ghx-field">${unassignedAvatarImg}</span>`,
-// }
-//
-// const unassignedAvatarElement = createUnassignedAvatarImgElement()
-// avatarElement.innerHTML = `<span class="bju-subtask-avatar">${unassignedAvatarImg}</span>`
 
 /**
  * Functions
@@ -66,17 +44,6 @@ function setupAvatarData(avatar, issueKey) {
 	return avatar
 }
 
-// function injectUnassignedAvatarHtml(element) {
-// 	let avatar = element.querySelector(`.${config.avatar.className}`)
-//
-// 	if (avatar === null) {
-// 		avatar = avatar.in
-// 		element.innerHTML = unassignedAvatarHtml[pageType] + element.innerHTML
-// 	}  else {
-// 		avatar.setAttribute(avatar)
-// 	}
-// }
-
 function injectUnassignedAvatars() {
 	let issues = getAllIssues()
 
@@ -104,7 +71,7 @@ function injectUnassignedAvatars() {
 function injectUnassignedAvatarsToSubtasks() {
 	let avatar
 
-	let subtasks = findSubtasksWithIssueKeys()
+	let subtasks = getSubtasksWithIssueKeys()
 
 	for (let i = 0; i < subtasks.length; i++) {
 		avatar = getSubtaskAvatar(subtasks[i].element)

--- a/src/js/modules/assign/components/unassignedAvatar.js
+++ b/src/js/modules/assign/components/unassignedAvatar.js
@@ -33,7 +33,7 @@ const pageType = getCurrentPageType()
 // 	'board': `<span class="ghx-field">${unassignedAvatarImg}</span>`,
 // }
 //
-const unassignedAvatarElement = createUnassignedAvatarImgElement()
+// const unassignedAvatarElement = createUnassignedAvatarImgElement()
 // avatarElement.innerHTML = `<span class="bju-subtask-avatar">${unassignedAvatarImg}</span>`
 
 /**
@@ -110,7 +110,7 @@ function injectUnassignedAvatarsToSubtasks() {
 		avatar = getSubtaskAvatar(subtasks[i].element)
 
 		if (avatar === false) {
-			avatar = setupAvatarData(unassignedAvatarElement, subtasks[i].issueKey)
+			avatar = setupAvatarData(createUnassignedAvatarImgElement(), subtasks[i].issueKey)
 			avatar = wrapElementWithSpan(avatar, 'bju-subtask-avatar')
 
 			injectUnassignedAvatarHtmlToSubtask(subtasks[i].element, avatar)

--- a/src/js/modules/assign/components/unassignedAvatar.js
+++ b/src/js/modules/assign/components/unassignedAvatar.js
@@ -10,12 +10,6 @@ import { findSubtasks, getSubtasksWithIssueKeys } from '../../../jira/components
 import { getSubtaskAvatar } from '../../../jira/components/Subtask'
 
 /**
- * Constants
- */
-
-const pageType = getCurrentPageType()
-
-/**
  * Functions
  */
 
@@ -38,6 +32,7 @@ function wrapElementWithSpan(element, className) {
 	return span
 }
 
+// TODO: Should be renamed
 function setupAvatarData(avatar, issueKey) {
 	avatar.setAttribute('data-bju-assign', 'on')
 	avatar.setAttribute('data-bju-issue-key', issueKey)
@@ -45,14 +40,14 @@ function setupAvatarData(avatar, issueKey) {
 	return avatar
 }
 
-function injectUnassignedAvatars() {
+function setupIssuesAvatars() {
 	let issues = getAllIssues()
-
-	debug('unassignedAvatar::injectUnassignedAvatars::issues', issues)
+	let pageType = getCurrentPageType()
 
 	for (let i = 0; i < issues.length; i++) {
 		let issueKey = getIssueKey(issues[i])
-		let avatar = getIssueAvatar(issues[i])
+		let avatarContainer = getIssueAvatarContainer(issues[i], pageType)
+		let avatar = getIssueAvatar(avatarContainer)
 
 		if (avatar !== null) {
 			setupAvatarData(avatar, issueKey)
@@ -69,7 +64,7 @@ function injectUnassignedAvatars() {
 	}
 }
 
-function injectUnassignedAvatarsToSubtasks() {
+function setupSubtasksAvatars() {
 	let avatar
 
 	let subtasks = getSubtasksWithIssueKeys()
@@ -101,12 +96,22 @@ function createUnassignedAvatar(issueKey, wrapWithSpan=false) {
 	return avatar
 }
 
+const rebind = async (config = {}) => {
+	if (!config.hasOwnProperty('skipIssues')) {
+		await setupIssuesAvatars()
+	}
+	if (!config.hasOwnProperty('skipSubtasks')) {
+		await setupSubtasksAvatars()
+	}
+}
+
 const init = async () => {
-	await injectUnassignedAvatars()
-	await injectUnassignedAvatarsToSubtasks()
+	await setupIssuesAvatars()
+	await setupSubtasksAvatars()
 }
 
 export default {
 	init,
-	createUnassignedAvatar
+	createUnassignedAvatar,
+	rebind
 }

--- a/src/js/modules/modules.js
+++ b/src/js/modules/modules.js
@@ -1,0 +1,11 @@
+import { debug } from '../lib/logger'
+
+import Assign from './assign/assign.content'
+
+function init() {
+	Assign.init()
+}
+
+export default {
+	init
+}

--- a/src/options.html
+++ b/src/options.html
@@ -68,7 +68,5 @@
 				</div>
 			</div>
 		</div>
-
-		<!-- <script src="options.bundle.js"></script> -->
 	</body>
 </html>


### PR DESCRIPTION
https://github.com/adamkarminski/better-jira-ux/projects/1#card-36212517

- Using a dirty hack, I was able to detect subtasks on a page.
- Using another dirty hack, I recognize if the Issue Detail View panel has been rerendered so the extension can rebind avatars.
- Introduced Jira Events API - a module that aims at using MutationObservers and other events as input and emit custom Jira events as output, allowing other modules to react to them.

I'm not proud, but it works and it's time to live-test it.